### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/calc-at-point.el
+++ b/calc-at-point.el
@@ -3,7 +3,7 @@
 ;; Author: Sebastian Wålinder <s.walinder@gmail.com>
 ;; URL: https://github.com/walseb/calc-at-point
 ;; Version: 1.0
-;; Package-Requires: ((emacs "26") (dash "2.12.0") (dash-functional "1.2.0"))
+;; Package-Requires: ((emacs "26") (dash "2.18.0"))
 ;; Keywords: convenience
 
 ;; calc-at-point is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
 
 ;;; Code:
 (require 'dash)
-(require 'dash-functional)
 (require 'calc)
 (require 'thingatpt)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218